### PR TITLE
Fix/void is reserved word

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: php
 php:
+    - 7.0
+    - 7.1
+    - 7.2
     - 7.3
+    - 7.4snapshot
 before_install:
     - phpenv config-rm xdebug.ini || true
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.3.1",
         "codeception/base": "^2.5",
-        "weirdan/codeception-psalm-module": "dev-master"
+        "weirdan/codeception-psalm-module": "^0.1.0"
     },
     "extra": {
         "psalm": {

--- a/stubs/Assert.php
+++ b/stubs/Assert.php
@@ -100,8 +100,9 @@ abstract class Assert
      * @param mixed  $actual
      * @param string $message
      * @psalm-assert =T $actual
+     * @return void
      */
-    function assertSame($expected, $actual, $message = '') : void {}
+    function assertSame($expected, $actual, $message = '') {}
 
     /**
      * Asserts that two variables are not the same.
@@ -111,6 +112,7 @@ abstract class Assert
      * @param mixed  $actual
      * @param string $message
      * @psalm-assert !=T $actual
+     * @return void
      */
-    function assertNotSame($expected, $actual, $message = '') : void {}
+    function assertNotSame($expected, $actual, $message = '') {}
 }

--- a/stubs/Assert.php
+++ b/stubs/Assert.php
@@ -91,7 +91,7 @@ abstract class Assert
      * @psalm-assert !null $actual
      */
     public static function assertNotNull($actual, $message = '') {}
-    
+
     /**
      * Asserts that two variables are the same.
      *
@@ -102,7 +102,7 @@ abstract class Assert
      * @psalm-assert =T $actual
      */
     function assertSame($expected, $actual, $message = '') : void {}
-    
+
     /**
      * Asserts that two variables are not the same.
      *

--- a/stubs/Assert_75.php
+++ b/stubs/Assert_75.php
@@ -6,133 +6,155 @@ abstract class Assert
     /**
      * @param mixed $actual
      * @psalm-assert array $actual
+     * @return void
      */
-    public static function assertIsArray($actual, string $message = ''): void {}
+    public static function assertIsArray($actual, string $message = '') {}
 
     /**
      * @param mixed $actual
      * @psalm-assert bool $actual
+     * @return void
      */
-    public static function assertIsBool($actual, string $message = ''): void {}
+    public static function assertIsBool($actual, string $message = '') {}
 
     /**
      * @param mixed $actual
      * @psalm-assert float $actual
+     * @return void
      */
-    public static function assertIsFloat($actual, string $message = ''): void {}
+    public static function assertIsFloat($actual, string $message = '') {}
 
     /**
      * @param mixed $actual
      * @psalm-assert int $actual
+     * @return void
      */
-    public static function assertIsInt($actual, string $message = ''): void {}
+    public static function assertIsInt($actual, string $message = '') {}
 
     /**
      * @param mixed $actual
      * @psalm-assert numeric $actual
+     * @return void
      */
-    public static function assertIsNumeric($actual, string $message = ''): void {}
+    public static function assertIsNumeric($actual, string $message = '') {}
 
     /**
      * @param mixed $actual
      * @psalm-assert object $actual
+     * @return void
      */
-    public static function assertIsObject($actual, string $message = ''): void {}
+    public static function assertIsObject($actual, string $message = '') {}
 
     /**
      * @param mixed $actual
      * @psalm-assert resource $actual
+     * @return void
      */
-    public static function assertIsResource($actual, string $message = ''): void {}
+    public static function assertIsResource($actual, string $message = '') {}
 
     /**
      * @param mixed $actual
      * @psalm-assert string $actual
+     * @return void
      */
-    public static function assertIsString($actual, string $message = ''): void {}
+    public static function assertIsString($actual, string $message = '') {}
 
     /**
      * @param mixed $actual
      * @psalm-assert scalar $actual
+     * @return void
      */
-    public static function assertIsScalar($actual, string $message = ''): void {}
+    public static function assertIsScalar($actual, string $message = '') {}
 
     /**
      * @param mixed $actual
      * @psalm-assert callable $actual
+     * @return void
      */
-    public static function assertIsCallable($actual, string $message = ''): void {}
+    public static function assertIsCallable($actual, string $message = '') {}
 
     /**
      * @param mixed $actual
      * @psalm-assert iterable $actual
+     * @return void
      */
-    public static function assertIsIterable($actual, string $message = ''): void {}
+    public static function assertIsIterable($actual, string $message = '') {}
 
     /**
      * @param mixed $actual
      * @psalm-assert !array $actual
+     * @return void
      */
-    public static function assertIsNotArray($actual, string $message = ''): void {}
+    public static function assertIsNotArray($actual, string $message = '') {}
 
     /**
      * @param mixed $actual
      * @psalm-assert !bool $actual
+     * @return void
      */
-    public static function assertIsNotBool($actual, string $message = ''): void {}
+    public static function assertIsNotBool($actual, string $message = '') {}
 
     /**
      * @param mixed $actual
      * @psalm-assert !float $actual
+     * @return void
      */
-    public static function assertIsNotFloat($actual, string $message = ''): void {}
+    public static function assertIsNotFloat($actual, string $message = '') {}
 
     /**
      * @param mixed $actual
      * @psalm-assert !int $actual
+     * @return void
      */
-    public static function assertIsNotInt($actual, string $message = ''): void {}
+    public static function assertIsNotInt($actual, string $message = '') {}
 
     /**
      * @param mixed $actual
      * @psalm-assert !numeric $actual
+     * @return void
      */
-    public static function assertIsNotNumeric($actual, string $message = ''): void {}
+    public static function assertIsNotNumeric($actual, string $message = '') {}
 
     /**
      * @param mixed $actual
      * @psalm-assert !object $actual
+     * @return void
      */
-    public static function assertIsNotObject($actual, string $message = ''): void {}
+    public static function assertIsNotObject($actual, string $message = '') {}
 
     /**
      * @param mixed $actual
      * @psalm-assert !resource $actual
+     * @return void
      */
-    public static function assertIsNotResource($actual, string $message = ''): void {}
+    public static function assertIsNotResource($actual, string $message = '') {}
 
     /**
      * @param mixed $actual
      * @psalm-assert !string $actual
+     * @return void
      */
-    public static function assertIsNotString($actual, string $message = ''): void {}
+    public static function assertIsNotString($actual, string $message = '') {}
 
     /**
      * @param mixed $actual
      * @psalm-assert !scalar $actual
+     * @return void
      */
-    public static function assertIsNotScalar($actual, string $message = ''): void {}
+    public static function assertIsNotScalar($actual, string $message = '') {}
 
     /**
      * @param mixed $actual
      * @psalm-assert !callable $actual
+     * @return void
      */
-    public static function assertIsNotCallable($actual, string $message = ''): void {}
+    public static function assertIsNotCallable($actual, string $message = '') {}
 
     /**
      * @param mixed $actual
      * @psalm-assert !iterable $actual
+     * @return void
      */
-    public static function assertIsNotIterable($actual, string $message = ''): void {}
+    public static function assertIsNotIterable($actual, string $message = '') {}
 
 }

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -20,8 +20,10 @@ class Acceptance extends \Codeception\Module
 
     /**
      * @Given /I have PHPUnit (newer than|older than) "([0-9.]+)" \(because of "([^"]+)"\)/
+     *
+     * @return void
      */
-    public function havePHPUnitOfACertainVersionRangeBecauseOf(string $operator, string $version, string $reason): void
+    public function havePHPUnitOfACertainVersionRangeBecauseOf(string $operator, string $version, string $reason)
     {
         if (!isset(self::VERSION_OPERATORS[$operator])) {
             throw new TestRuntimeException("Unknown operator: $operator");

--- a/tests/acceptance/Assert.feature
+++ b/tests/acceptance/Assert.feature
@@ -18,7 +18,11 @@ Feature: Assert
       function f(): \Exception {
         return rand(0,1) ? new \RuntimeException : new \InvalidArgumentException;
       }
-      function acceptsRuntimeException(\RuntimeException $_e): void {}
+
+      /**
+       * @return void
+       */
+      function acceptsRuntimeException(\RuntimeException $_e) {}
 
       $e = f();
       Assert::assertInstanceOf(\RuntimeException::class, $e);


### PR DESCRIPTION
when run under 7.0, plugin fails due to void being a reserved word

prerequisites: 
- [x] resolve weirdan/codeception-psalm-module#1