### PR TITLE
Stubbed expectException()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0",
-        "vimeo/psalm": "^3.0 || dev-master",
+        "vimeo/psalm": "^3.0.8 || dev-master",
         "composer/semver": "^1.4",
         "muglug/package-versions-56": "^1.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "phpunit/phpunit": "^5.0 || ^6.0 || ^7.0",
+        "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0",
         "vimeo/psalm": "^3.0 || dev-master",
         "composer/semver": "^1.4",
         "muglug/package-versions-56": "^1.2"

--- a/stubs/TestCase.php
+++ b/stubs/TestCase.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignoreFile
 namespace PHPUnit\Framework;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -30,4 +30,9 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      * @return ObjectProphecy<T>
      */
     public function prophesize($classOrInterface): ObjectProphecy {}
+    /**
+     * @param class-string<\Throwable> $exception
+     * @return void
+     */
+    public function expectException(string $exception) {}
 }

--- a/tests/acceptance/TestCase.feature
+++ b/tests/acceptance/TestCase.feature
@@ -1,0 +1,42 @@
+Feature: TestCase
+  In order to have typed TestCases
+  As a Psalm user
+  I need Psalm to typecheck my test cases
+
+  Background:
+    Given I have the following code preamble
+      """
+      <?php
+      use PHPUnit\Framework\TestCase;
+
+      """
+
+  Scenario: TestCase::expectException() rejects non-throwables
+    Given I have the following code
+      """
+      class MyTestCase extends TestCase 
+      {
+        /** @return void */
+        public function testSomething() {
+          $this->expectException(MyTestCase::class);
+        }
+      }
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type            | Message               |
+      | InvalidArgument | Argument 1 of PHPUnit\Framework\TestCase::expectException expects class-string<Throwable>, MyTestCase::class provided |
+
+  Scenario: TestCase::expectException() accepts throwables
+    Given I have the following code
+      """
+      class MyTestCase extends TestCase 
+      {
+        /** @return void */
+        public function testSomething() {
+          $this->expectException(\InvalidArgumentException::class);
+        }
+      }
+      """
+    When I run Psalm
+    Then I see no errors

--- a/tests/acceptance/TestCase.feature
+++ b/tests/acceptance/TestCase.feature
@@ -12,6 +12,7 @@ Feature: TestCase
       """
 
   Scenario: TestCase::expectException() rejects non-throwables
+    Given I have Psalm newer than "3.0.12" (because of "missing functionality")
     Given I have the following code
       """
       class MyTestCase extends TestCase 


### PR DESCRIPTION
# Features
This tightens the constraints on `expectException()`, requiring it to be a descendant of Throwable.

# Breaking changes
- bumped Psalm dependency to >= 3.0.8 (before that `class-string<Throwable>` was not supported)

# Other changes
- bumped PHPUnit version (as we really provide stubs for 6+)

/cc @SignpostMarv 