### PR TITLE
Data providers and dead code detection tweaks

### DIFF
--- a/Exception/UnsupportedPsalmVersion.php
+++ b/Exception/UnsupportedPsalmVersion.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+namespace Psalm\PhpUnitPlugin\Exception;
+
+use RuntimeException;
+
+class UnsupportedPsalmVersion extends RuntimeException
+{
+}

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "autoload": {
         "psr-4": {
             "Psalm\\PhpUnitPlugin\\": ["."],
-            "Psalm\\PhpUnitPlugin\\Hooks\\": ["hooks"]
+            "Psalm\\PhpUnitPlugin\\Hooks\\": ["hooks"],
+            "Psalm\\PhpUnitPlugin\\Exception\\" : ["Exception"]
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.3.1",
         "codeception/base": "^2.5",
-        "weirdan/codeception-psalm-module": "^0.1.0"
+        "weirdan/codeception-psalm-module": "^0.2.1"
     },
     "extra": {
         "psalm": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0",
-        "vimeo/psalm": "^3.0.10 || dev-master",
+        "vimeo/psalm": "^3.0.13 || dev-master",
         "composer/semver": "^1.4",
         "muglug/package-versions-56": "^1.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0",
-        "vimeo/psalm": "^3.0.8 || dev-master",
+        "vimeo/psalm": "^3.0.10 || dev-master",
         "composer/semver": "^1.4",
         "muglug/package-versions-56": "^1.2"
     },

--- a/hooks/TestCaseHandler.php
+++ b/hooks/TestCaseHandler.php
@@ -92,6 +92,8 @@ class TestCaseHandler implements AfterClassLikeVisitInterface, AfterClassLikeAna
                 $provider_return_type = $codebase->getMethodReturnType($provider_method_id, $classStorage->name);
                 assert(null !== $provider_return_type);
 
+                $provider_return_type_string = $provider_return_type->getId();
+
                 $provider_return_type_location = $codebase->getMethodReturnTypeLocation($provider_method_id);
                 assert(null !== $provider_return_type_location);
 
@@ -107,7 +109,7 @@ class TestCaseHandler implements AfterClassLikeVisitInterface, AfterClassLikeAna
                 )) {
                     IssueBuffer::accepts(new Issue\InvalidReturnType(
                         'Providers must return ' . $expected_provider_return_type->getId()
-                        . ', ' . $provider_return_type->getId() . ' provided',
+                        . ', ' . $provider_return_type_string . ' provided',
                         $provider_return_type_location
                     ));
 
@@ -118,7 +120,7 @@ class TestCaseHandler implements AfterClassLikeVisitInterface, AfterClassLikeAna
                     if (!$type->isIterable($codebase)) {
                         IssueBuffer::accepts(new Issue\InvalidReturnType(
                             'Providers must return ' . $expected_provider_return_type->getId()
-                            . ', ' . $provider_return_type->getId() . ' provided',
+                            . ', ' . $provider_return_type_string . ' provided',
                             $provider_return_type_location
                         ));
                         continue;
@@ -143,7 +145,7 @@ class TestCaseHandler implements AfterClassLikeVisitInterface, AfterClassLikeAna
                 )) {
                     IssueBuffer::accepts(new Issue\InvalidReturnType(
                         'Providers must return ' . $expected_provider_return_type->getId()
-                        . ', ' . $provider_return_type->getId() . ' provided',
+                        . ', ' . $provider_return_type_string . ' provided',
                         $provider_return_type_location
                     ));
                     continue;
@@ -159,7 +161,7 @@ class TestCaseHandler implements AfterClassLikeVisitInterface, AfterClassLikeAna
                     $codebase,
                     $method_id,
                     $provider_method_id,
-                    $provider_return_type,
+                    $provider_return_type_string,
                     $provider_docblock_location
                 ) {
                     assert(null !== $param->type);
@@ -170,7 +172,7 @@ class TestCaseHandler implements AfterClassLikeVisitInterface, AfterClassLikeAna
                             'Argument ' . ($param_offset + 1) . ' of ' . $method_id
                             . ' expects ' . $param->type->getId() . ', '
                             . $potential_argument_type->getId() . ' provided'
-                            . ' by ' . $provider_method_id . '():(' . $provider_return_type->getId() . ')',
+                            . ' by ' . $provider_method_id . '():(' . $provider_return_type_string . ')',
                             $provider_docblock_location
                         ));
                     } else {
@@ -178,7 +180,7 @@ class TestCaseHandler implements AfterClassLikeVisitInterface, AfterClassLikeAna
                             'Argument ' . ($param_offset + 1) . ' of ' . $method_id
                             . ' expects ' . $param->type->getId() . ', '
                             . $potential_argument_type->getId() . ' provided'
-                            . ' by ' . $provider_method_id . '():(' . $provider_return_type->getId() . ')',
+                            . ' by ' . $provider_method_id . '():(' . $provider_return_type_string . ')',
                             $provider_docblock_location
                         ));
                     }
@@ -204,7 +206,7 @@ class TestCaseHandler implements AfterClassLikeVisitInterface, AfterClassLikeAna
                             . ' - expecting ' . $method_storage->required_param_count
                             . ' but saw ' . count($potential_argument_types)
                             . ' provided by ' . $provider_method_id . '()'
-                            .  ':(' . $provider_return_type->getId() . ')',
+                            .  ':(' . $provider_return_type_string . ')',
                             $provider_docblock_location,
                             $method_id
                         ));

--- a/hooks/TestCaseHandler.php
+++ b/hooks/TestCaseHandler.php
@@ -134,7 +134,8 @@ class TestCaseHandler implements AfterClassLikeVisitInterface, AfterClassLikeAna
 
                 // unionize iterable so that instead of array<int,string>|Traversable<object|int>
                 // we get iterable<int|object,string|int>
-
+                //
+                // TODO: this may get implemented in a future Psalm version, remove it then
                 $provider_return_type = self::unionizeIterables($codebase, $provider_return_type);
 
                 if (!self::isTypeContainedByType(
@@ -236,7 +237,6 @@ class TestCaseHandler implements AfterClassLikeVisitInterface, AfterClassLikeAna
                         ));
                     }
 
-
                     foreach ($method_storage->params as $param_offset => $param) {
                         if (!isset($potential_argument_types[$param_offset])) {
                             break;
@@ -257,12 +257,15 @@ class TestCaseHandler implements AfterClassLikeVisitInterface, AfterClassLikeAna
     ): bool {
         if (method_exists($codebase, 'isTypeContainedByType')) {
             return (bool) $codebase->isTypeContainedByType($input_type, $container_type);
-        } elseif (class_exists(\Psalm\Internal\Analyzer\TypeAnalyzer::class, true)
+        }
+
+        /** @psalm-suppress RedundantCondition */
+        if (class_exists(\Psalm\Internal\Analyzer\TypeAnalyzer::class, true)
             && method_exists(\Psalm\Internal\Analyzer\TypeAnalyzer::class, 'isContainedBy')) {
             return \Psalm\Internal\Analyzer\TypeAnalyzer::isContainedBy($codebase, $input_type, $container_type);
-        } else {
-            throw new UnsupportedPsalmVersion();
         }
+
+        throw new UnsupportedPsalmVersion();
     }
 
     private static function canTypeBeContainedByType(
@@ -272,12 +275,15 @@ class TestCaseHandler implements AfterClassLikeVisitInterface, AfterClassLikeAna
     ): bool {
         if (method_exists($codebase, 'canTypeBeContainedByType')) {
             return (bool) $codebase->canTypeBeContainedByType($input_type, $container_type);
-        } elseif (class_exists(\Psalm\Internal\Analyzer\TypeAnalyzer::class, true)
+        }
+
+        /** @psalm-suppress RedundantCondition */
+        if (class_exists(\Psalm\Internal\Analyzer\TypeAnalyzer::class, true)
             && method_exists(\Psalm\Internal\Analyzer\TypeAnalyzer::class, 'canBeContainedBy')) {
             return \Psalm\Internal\Analyzer\TypeAnalyzer::canBeContainedBy($codebase, $input_type, $container_type);
-        } else {
-            throw new UnsupportedPsalmVersion();
         }
+
+        throw new UnsupportedPsalmVersion();
     }
 
     /**
@@ -291,7 +297,10 @@ class TestCaseHandler implements AfterClassLikeVisitInterface, AfterClassLikeAna
             assert($ret[0] instanceof Type\Union);
             assert($ret[1] instanceof Type\Union);
             return [$ret[0], $ret[1]];
-        } elseif (class_exists(\Psalm\Internal\Analyzer\Statements\Block\ForeachAnalyzer::class, true)
+        }
+
+        /** @psalm-suppress RedundantCondition */
+        if (class_exists(\Psalm\Internal\Analyzer\Statements\Block\ForeachAnalyzer::class, true)
             && method_exists(
                 \Psalm\Internal\Analyzer\Statements\Block\ForeachAnalyzer::class,
                 'getKeyValueParamsForTraversableObject'
@@ -311,9 +320,9 @@ class TestCaseHandler implements AfterClassLikeVisitInterface, AfterClassLikeAna
                 $iterable_key_type ?? Type::getMixed(),
                 $iterable_value_type ?? Type::getMixed(),
             ];
-        } else {
-            throw new UnsupportedPsalmVersion();
         }
+
+        throw new UnsupportedPsalmVersion();
     }
 
     private static function unionizeIterables(Codebase $codebase, Type\Union $iterables): Type\Atomic\TIterable

--- a/hooks/TestCaseHandler.php
+++ b/hooks/TestCaseHandler.php
@@ -1,20 +1,22 @@
-<?php
+<?php declare(strict_types=1);
 namespace Psalm\PhpUnitPlugin\Hooks;
 
 use PHPUnit\Framework\TestCase;
-use PhpParser\Comment\Doc;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
-use Psalm\CodeLocation;
 use Psalm\Codebase;
 use Psalm\DocComment;
 use Psalm\FileSource;
 use Psalm\IssueBuffer;
-use Psalm\Issue\UndefinedMethod;
+use Psalm\Issue;
+use Psalm\PhpUnitPlugin\Exception\UnsupportedPsalmVersion;
 use Psalm\Plugin\Hook\AfterClassLikeAnalysisInterface;
 use Psalm\Plugin\Hook\AfterClassLikeVisitInterface;
 use Psalm\StatementsSource;
 use Psalm\Storage\ClassLikeStorage;
+use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Storage\MethodStorage;
+use Psalm\Type;
 
 class TestCaseHandler implements AfterClassLikeVisitInterface, AfterClassLikeAnalysisInterface
 {
@@ -41,18 +43,23 @@ class TestCaseHandler implements AfterClassLikeVisitInterface, AfterClassLikeAna
      * {@inheritDoc}
      */
     public static function afterStatementAnalysis(
-        ClassLike $classNode,
-        ClassLikeStorage $classStorage,
+        ClassLike $class_node,
+        ClassLikeStorage $class_storage,
         StatementsSource $statements_source,
         Codebase $codebase,
         array &$file_replacements = []
     ) {
-        foreach ($classStorage->methods as $method_name => $method_storage) {
+        if (!$codebase->classExtends($class_storage->name, TestCase::class)) {
+            return null;
+        }
+
+        /** @var MethodStorage $method_storage */
+        foreach ($class_storage->methods as $method_name => $method_storage) {
             if (!$method_storage->location) {
                 continue;
             }
 
-            $stmt_method = $classNode->getMethod($method_name);
+            $stmt_method = $class_node->getMethod($method_name);
 
             if (!$stmt_method) {
                 throw new \RuntimeException('Failed to find ' . $method_name);
@@ -60,25 +67,235 @@ class TestCaseHandler implements AfterClassLikeVisitInterface, AfterClassLikeAna
 
             $specials = self::getSpecials($stmt_method);
 
+            $method_id = $class_storage->name . '::' . $method_storage->cased_name;
+
             if (!isset($specials['dataProvider'])) {
                 continue;
             }
 
             foreach ($specials['dataProvider'] as $line => $provider) {
-                $provider_method_id = $classStorage->name . '::' . (string) $provider;
+                $provider_method_id = $class_storage->name . '::' . (string) $provider;
+
+                $provider_docblock_location = clone $method_storage->location;
+                $provider_docblock_location->setCommentLine($line);
 
                 if (!$codebase->methodExists($provider_method_id)) {
-                    $location = clone $method_storage->location;
-                    $location->setCommentLine($line);
-
-                    IssueBuffer::accepts(new UndefinedMethod(
+                    IssueBuffer::accepts(new Issue\UndefinedMethod(
                         'Provider method ' . $provider_method_id . ' is not defined',
-                        $location,
+                        $provider_docblock_location,
                         $provider_method_id
                     ));
+
+                    continue;
+                }
+
+                $provider_return_type = $codebase->getMethodReturnType($provider_method_id, $classStorage->name);
+                assert(null !== $provider_return_type);
+
+                $provider_return_type_location = $codebase->getMethodReturnTypeLocation($provider_method_id);
+                assert(null !== $provider_return_type_location);
+
+                $expected_provider_return_type = new Type\Atomic\TIterable([
+                    Type::combineUnionTypes(Type::getInt(), Type::getString()),
+                    Type::getArray(),
+                ]);
+
+                if (!self::isTypeContainedByType(
+                    $codebase,
+                    $provider_return_type,
+                    new Type\Union([$expected_provider_return_type])
+                )) {
+                    IssueBuffer::accepts(new Issue\InvalidReturnType(
+                        'Providers must return ' . $expected_provider_return_type->getId()
+                        . ', ' . $provider_return_type->getId() . ' provided',
+                        $provider_return_type_location
+                    ));
+
+                    continue;
+                }
+
+                foreach ($provider_return_type->getTypes() as $type) {
+                    if (!$type->isIterable($codebase)) {
+                        IssueBuffer::accepts(new Issue\InvalidReturnType(
+                            'Providers must return ' . $expected_provider_return_type->getId()
+                            . ', ' . $provider_return_type->getId() . ' provided',
+                            $provider_return_type_location
+                        ));
+                        continue;
+                    }
+                }
+
+                // unionize iterable so that instead of array<int,string>|Traversable<object|int>
+                // we get iterable<int|object,string|int>
+
+                $provider_return_type = self::unionizeIterables($codebase, $provider_return_type);
+
+                // this is basically a repetition of above $expected_provider_return_type check
+                // but older Psalm versions couldn't check iterable descendants (see vimeo/psalm#1359)
+                if (!self::isTypeContainedByType(
+                    $codebase,
+                    $provider_return_type->type_params[0],
+                    $expected_provider_return_type->type_params[0]
+                ) || !self::isTypeContainedByType(
+                    $codebase,
+                    $provider_return_type->type_params[1],
+                    $expected_provider_return_type->type_params[1]
+                )) {
+                    IssueBuffer::accepts(new Issue\InvalidReturnType(
+                        'Providers must return ' . $expected_provider_return_type->getId()
+                        . ', ' . $provider_return_type->getId() . ' provided',
+                        $provider_return_type_location
+                    ));
+                    continue;
+                }
+
+                $checkParam = function (
+                    Type\Union $potential_argument_type,
+                    FunctionLikeParameter $param,
+                    int $param_offset
+                ) use (
+                    $codebase,
+                    $method_id,
+                    $provider_method_id,
+                    $provider_return_type,
+                    $provider_docblock_location
+                ): void {
+                    assert(null !== $param->type);
+                    if (self::isTypeContainedByType($codebase, $potential_argument_type, $param->type)) {
+                        // ok
+                    } elseif (self::canTypeBeContainedByType($codebase, $potential_argument_type, $param->type)) {
+                        IssueBuffer::accepts(new Issue\PossiblyInvalidArgument(
+                            'Argument ' . ($param_offset + 1) . ' of ' . $method_id
+                            . ' expects ' . $param->type->getId() . ', '
+                            . $potential_argument_type->getId() . ' provided'
+                            . ' by ' . $provider_method_id . '():(' . $provider_return_type->getId() . ')',
+                            $provider_docblock_location
+                        ));
+                    } else {
+                        IssueBuffer::accepts(new Issue\InvalidArgument(
+                            'Argument ' . ($param_offset + 1) . ' of ' . $method_id
+                            . ' expects ' . $param->type->getId() . ', '
+                            . $potential_argument_type->getId() . ' provided'
+                            . ' by ' . $provider_method_id . '():(' . $provider_return_type->getId() . ')',
+                            $provider_docblock_location
+                        ));
+                    }
+                };
+
+                /** @var Type\Atomic\TArray|Type\Atomic\ObjectLike $dataset_type */
+                $dataset_type = $provider_return_type->type_params[1]->getTypes()['array'];
+
+                if ($dataset_type instanceof Type\Atomic\TArray) {
+                    // check that all of the required (?) params accept value type
+                    $potential_argument_type = $dataset_type->type_params[1];
+                    foreach ($method_storage->params as $param_offset => $param) {
+                        $checkParam($potential_argument_type, $param, $param_offset);
+                    }
+                } else {
+                    // iterate over all params checking if corresponding value type is acceptable
+                    // let's hope properties are sorted in array order
+                    $potential_argument_types = array_values($dataset_type->properties);
+
+                    if (count($potential_argument_types) < $method_storage->required_param_count) {
+                        IssueBuffer::accepts(new Issue\TooFewArguments(
+                            'Too few arguments for ' . $method_id
+                            . ' - expecting ' . $method_storage->required_param_count
+                            . ' but saw ' . count($potential_argument_types)
+                            . ' provided by ' . $provider_method_id . '()'
+                            .  ':(' . $provider_return_type->getId() . ')',
+                            $provider_docblock_location,
+                            $method_id
+                        ));
+                    }
+
+
+                    foreach ($method_storage->params as $param_offset => $param) {
+                        if (!isset($potential_argument_types[$param_offset])) {
+                            break;
+                        }
+                        $potential_argument_type = $potential_argument_types[$param_offset];
+
+                        $checkParam($potential_argument_type, $param, $param_offset);
+                    }
                 }
             }
         }
+    }
+
+    private static function isTypeContainedByType(
+        Codebase $codebase,
+        Type\Union $input_type,
+        Type\Union $container_type
+    ): bool {
+        if (method_exists($codebase, 'isTypeContainedByType')) {
+            return (bool) $codebase->isTypeContainedByType($input_type, $container_type);
+        } elseif (class_exists(\Psalm\Internal\Analyzer\TypeAnalyzer::class, true)
+            && method_exists(\Psalm\Internal\Analyzer\TypeAnalyzer::class, 'isContainedBy')) {
+            return \Psalm\Internal\Analyzer\TypeAnalyzer::isContainedBy($codebase, $input_type, $container_type);
+        } else {
+            throw new UnsupportedPsalmVersion();
+        }
+    }
+
+    private static function canTypeBeContainedByType(
+        Codebase $codebase,
+        Type\Union $input_type,
+        Type\Union $container_type
+    ): bool {
+        if (method_exists($codebase, 'canTypeBeContainedByType')) {
+            return (bool) $codebase->canTypeBeContainedByType($input_type, $container_type);
+        } elseif (class_exists(\Psalm\Internal\Analyzer\TypeAnalyzer::class, true)
+            && method_exists(\Psalm\Internal\Analyzer\TypeAnalyzer::class, 'canBeContainedBy')) {
+            return \Psalm\Internal\Analyzer\TypeAnalyzer::canBeContainedBy($codebase, $input_type, $container_type);
+        } else {
+            throw new UnsupportedPsalmVersion();
+        }
+    }
+
+    private static function unionizeIterables(Codebase $codebase, Type\Union $iterables): Type\Atomic\TIterable
+    {
+        /** @var Type\Union[] $key_types */
+        $key_types = [];
+
+        /** @var Type\Union[] $value_types */
+        $value_types = [];
+
+        foreach ($iterables->getTypes() as $type) {
+            if (!$type->isIterable($codebase)) {
+                throw new \RuntimeException('should be iterable');
+            }
+
+            if ($type instanceof Type\Atomic\TArray) {
+                $key_types[] = $type->type_params[0] ?? Type::getMixed();
+                $value_types[] = $type->type_params[1] ?? Type::getMixed();
+            } elseif ($type instanceof Type\Atomic\ObjectLike) {
+                $key_types[] = $type->getGenericKeyType();
+                $value_types[] = $type->getGenericValueType();
+            } elseif ($type instanceof Type\Atomic\TNamedObject || $type instanceof Type\Atomic\TIterable) {
+                $iterable_key_type = null;
+                $iterable_value_type = null;
+
+                \Psalm\Internal\Analyzer\Statements\Block\ForeachAnalyzer::getKeyValueParamsForTraversableObject(
+                    $type,
+                    $codebase,
+                    $iterable_key_type,
+                    $iterable_value_type
+                );
+                $key_types[] = $iterable_key_type ?? Type::getMixed();
+                $value_types[] = $iterable_value_type ?? Type::getMixed();
+            } else {
+                throw new \RuntimeException('unexpected type');
+            }
+        }
+
+        $combine = function (Type\Union $a, Type\Union $b) use ($codebase): Type\Union {
+            return Type::combineUnionTypes($a, $b, $codebase);
+        };
+
+        return new Type\Atomic\TIterable([
+            array_reduce($key_types, $combine, new Type\Union([])),
+            array_reduce($value_types, $combine, new Type\Union([]))
+        ]);
     }
 
 

--- a/hooks/TestCaseHandler.php
+++ b/hooks/TestCaseHandler.php
@@ -5,13 +5,18 @@ use PHPUnit\Framework\TestCase;
 use PhpParser\Comment\Doc;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
+use Psalm\CodeLocation;
 use Psalm\Codebase;
 use Psalm\DocComment;
 use Psalm\FileSource;
+use Psalm\IssueBuffer;
+use Psalm\Issue\UndefinedMethod;
+use Psalm\Plugin\Hook\AfterClassLikeAnalysisInterface;
 use Psalm\Plugin\Hook\AfterClassLikeVisitInterface;
+use Psalm\StatementsSource;
 use Psalm\Storage\ClassLikeStorage;
 
-class TestCaseHandler implements AfterClassLikeVisitInterface
+class TestCaseHandler implements AfterClassLikeVisitInterface, AfterClassLikeAnalysisInterface
 {
     /**
      * {@inheritDoc}
@@ -23,12 +28,59 @@ class TestCaseHandler implements AfterClassLikeVisitInterface
         Codebase $codebase,
         array &$file_replacements = []
     ) {
-        if ($codebase->classExtends($classStorage->name, TestCase::class)) {
-            if (self::hasInitializers($classStorage, $classNode)) {
-                $classStorage->suppressed_issues[] = 'MissingConstructor';
+        if (!$codebase->classExtends($classStorage->name, TestCase::class)) {
+            return;
+        }
+
+        if (self::hasInitializers($classStorage, $classNode)) {
+            $classStorage->suppressed_issues[] = 'MissingConstructor';
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function afterStatementAnalysis(
+        ClassLike $classNode,
+        ClassLikeStorage $classStorage,
+        StatementsSource $statements_source,
+        Codebase $codebase,
+        array &$file_replacements = []
+    ) {
+        foreach ($classStorage->methods as $method_name => $method_storage) {
+            if (!$method_storage->location) {
+                continue;
+            }
+
+            $stmt_method = $classNode->getMethod($method_name);
+
+            if (!$stmt_method) {
+                throw new \RuntimeException('Failed to find ' . $method_name);
+            }
+
+            $specials = self::getSpecials($stmt_method);
+
+            if (!isset($specials['dataProvider'])) {
+                continue;
+            }
+
+            foreach ($specials['dataProvider'] as $line => $provider) {
+                $provider_method_id = $classStorage->name . '::' . (string) $provider;
+
+                if (!$codebase->methodExists($provider_method_id)) {
+                    $location = clone $method_storage->location;
+                    $location->setCommentLine($line);
+
+                    IssueBuffer::accepts(new UndefinedMethod(
+                        'Provider method ' . $provider_method_id . ' is not defined',
+                        $location,
+                        $provider_method_id
+                    ));
+                }
             }
         }
     }
+
 
     private static function hasInitializers(ClassLikeStorage $storage, ClassLike $stmt): bool
     {
@@ -50,20 +102,21 @@ class TestCaseHandler implements AfterClassLikeVisitInterface
 
     private static function isBeforeInitializer(ClassMethod $method): bool
     {
-        /** @var string[] $comments */
-        $comments = $method->getAttribute('comments', []);
+        $specials = self::getSpecials($method);
+        return isset($specials['before']);
+    }
 
-        foreach ($comments as $comment) {
-            if (!$comment instanceof Doc) {
-                continue;
-            }
+    /** @return array<string, array<int,string>> */
+    private static function getSpecials(ClassMethod $method): array
+    {
+        $docblock = $method->getDocComment();
 
-            $parsed_comment = DocComment::parse((string)$comment->getReformattedText());
-            if (isset($parsed_comment['specials']['before'])) {
-                return true;
+        if ($docblock) {
+            $parsed_comment = DocComment::parse((string)$docblock->getReformattedText(), $docblock->getLine());
+            if (isset($parsed_comment['specials'])) {
+                return $parsed_comment['specials'];
             }
         }
-
-        return false;
+        return [];
     }
 }

--- a/hooks/TestCaseHandler.php
+++ b/hooks/TestCaseHandler.php
@@ -149,7 +149,9 @@ class TestCaseHandler implements AfterClassLikeVisitInterface, AfterClassLikeAna
                     continue;
                 }
 
-                $checkParam = function (
+                $checkParam =
+                /** @return void */
+                function (
                     Type\Union $potential_argument_type,
                     FunctionLikeParameter $param,
                     int $param_offset
@@ -159,7 +161,7 @@ class TestCaseHandler implements AfterClassLikeVisitInterface, AfterClassLikeAna
                     $provider_method_id,
                     $provider_return_type,
                     $provider_docblock_location
-                ): void {
+                ) {
                     assert(null !== $param->type);
                     if (self::isTypeContainedByType($codebase, $potential_argument_type, $param->type)) {
                         // ok

--- a/hooks/TestCaseHandler.php
+++ b/hooks/TestCaseHandler.php
@@ -349,9 +349,11 @@ class TestCaseHandler implements AfterClassLikeVisitInterface, AfterClassLikeAna
             ]);
         }
 
-        $combine = function (?Type\Union $a, Type\Union $b) use ($codebase): Type\Union {
-            return $a ? Type::combineUnionTypes($a, $b, $codebase) : $b;
-        };
+        $combine =
+            /** @param null|Type\Union $a */
+            function ($a, Type\Union $b) use ($codebase): Type\Union {
+                return $a ? Type::combineUnionTypes($a, $b, $codebase) : $b;
+            };
 
         return new Type\Atomic\TIterable([
             array_reduce($key_types, $combine),

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,11 +1,15 @@
 <?xml version="1.0"?>
-<ruleset name="invajo">
+<ruleset name="phpunit-psalm-plugin">
     <!-- display progress -->
     <arg value="p"/>
     <arg name="colors"/>
 
     <!-- Paths to check -->
     <file>Plugin.php</file>
+    <file>tests/_support/Helper</file>
+    <file>tests/_support/AcceptanceTester.php</file>
+    <file>hooks</file>
+    <file>Exception</file>
 
 
     <!-- inherit rules from: -->

--- a/tests/acceptance/Assert.feature
+++ b/tests/acceptance/Assert.feature
@@ -4,7 +4,17 @@ Feature: Assert
   I need Psalm to typecheck asserts
 
   Background:
-    Given I have the following code preamble
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm>
+        <projectFiles><directory name="." /></projectFiles>
+        <plugins>
+          <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+        </plugins>
+      </psalm>
+      """
+    And I have the following code preamble
       """
       <?php
       namespace NS;

--- a/tests/acceptance/Assert75.feature
+++ b/tests/acceptance/Assert75.feature
@@ -4,7 +4,17 @@ Feature: Assert (PHPUnit 7.5+)
   I need Psalm to typecheck asserts
 
   Background:
-    Given I have the following code preamble
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm>
+        <projectFiles><directory name="." /></projectFiles>
+        <plugins>
+          <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+        </plugins>
+      </psalm>
+      """
+    And I have the following code preamble
       """
       <?php
       namespace NS;

--- a/tests/acceptance/TestCase.feature
+++ b/tests/acceptance/TestCase.feature
@@ -4,7 +4,20 @@ Feature: TestCase
   I need Psalm to typecheck my test cases
 
   Background:
-    Given I have the following code preamble
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm>
+        <projectFiles>
+          <directory name="."/>
+          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
+        </projectFiles>
+        <plugins>
+          <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+        </plugins>
+      </psalm>
+      """
+    And I have the following code preamble
       """
       <?php
       namespace NS;

--- a/tests/acceptance/TestCase.feature
+++ b/tests/acceptance/TestCase.feature
@@ -167,3 +167,249 @@ Feature: TestCase
       | Type            | Message                                               |
       | UndefinedMethod | Provider method NS\MyTestCase::provide is not defined |
     And I see no other errors
+
+  Scenario: Invalid iterable data provider is reported
+    Given I have the following code
+      """
+      class MyTestCase extends TestCase
+      {
+        /** @return iterable<int,int> */
+        public function provide() {
+          yield 1;
+        }
+        /**
+         * @return void
+         * @psalm-suppress UnusedMethod
+         * @dataProvider provide
+         */
+        public function testSomething(int $int) {
+          $this->assertEquals(1, $int);
+        }
+      }
+      new MyTestCase;
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type              | Message                                                                                           |
+      | InvalidReturnType | Providers must return iterable<int\|string, array<array-key, mixed>>, iterable<int, int> provided |
+
+  Scenario: Valid iterable data provider is allowed
+    Given I have the following code
+      """
+      class MyTestCase extends TestCase
+      {
+        /** @return iterable<int,array<int,int>> */
+        public function provide() {
+          yield [1];
+        }
+        /**
+         * @return void
+         * @psalm-suppress UnusedMethod
+         * @dataProvider provide
+         */
+        public function testSomething(int $int) {
+          $this->assertEquals(1, $int);
+        }
+      }
+      new MyTestCase;
+      """
+    When I run Psalm
+    Then I see no errors
+
+  Scenario: Invalid generator data provider is reported
+    Given I have the following code
+      """
+      class MyTestCase extends TestCase
+      {
+        /** @return \Generator<int,int,mixed,void> */
+        public function provide() {
+          yield 1;
+        }
+        /**
+         * @return void
+         * @psalm-suppress UnusedMethod
+         * @dataProvider provide
+         */
+        public function testSomething(int $int) {
+          $this->assertEquals(1, $int);
+        }
+      }
+      new MyTestCase;
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type              | Message                                                                                                         |
+      | InvalidReturnType | Providers must return iterable<int\|string, array<array-key, mixed>>, Generator<int, int, mixed, void> provided |
+
+  Scenario: Valid generator data provider is allowed
+    Given I have the following code
+      """
+      class MyTestCase extends TestCase
+      {
+        /** @return \Generator<int,array<int,int>,mixed,void> */
+        public function provide() {
+          yield [1];
+        }
+        /**
+         * @return void
+         * @psalm-suppress UnusedMethod
+         * @dataProvider provide
+         */
+        public function testSomething(int $int) {
+          $this->assertEquals(1, $int);
+        }
+      }
+      new MyTestCase;
+      """
+    When I run Psalm
+    Then I see no errors
+
+  Scenario: Invalid array data provider is reported
+    Given I have the following code
+      """
+      class MyTestCase extends TestCase
+      {
+        /** @return array<int,int> */
+        public function provide() {
+          return [1 => 1];
+        }
+        /**
+         * @return void
+         * @psalm-suppress UnusedMethod
+         * @dataProvider provide
+         */
+        public function testSomething(int $int) {
+          $this->assertEquals(1, $int);
+        }
+      }
+      new MyTestCase;
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type              | Message                                                                                        |
+      | InvalidReturnType | Providers must return iterable<int\|string, array<array-key, mixed>>, array<int, int> provided |
+
+  Scenario: Valid array data provider is allowed
+    Given I have the following code
+      """
+      class MyTestCase extends TestCase
+      {
+        /** @return array<string, array<int,int>> */
+        public function provide() {
+          return [
+            "data set name" => [1],
+          ];
+        }
+        /**
+         * @return void
+         * @psalm-suppress UnusedMethod
+         * @dataProvider provide
+         */
+        public function testSomething(int $int) {
+          $this->assertEquals(1, $int);
+        }
+      }
+      new MyTestCase;
+      """
+    When I run Psalm
+    Then I see no errors
+
+  Scenario: Valid object data provider is allowed
+    Given I have the following code
+      """
+      class MyTestCase extends TestCase
+      {
+        /** @return \ArrayObject<string,array<int,int>> */
+        public function provide() {
+          return new \ArrayObject([
+            "data set name" => [1],
+          ]);
+        }
+        /**
+         * @return void
+         * @psalm-suppress UnusedMethod
+         * @dataProvider provide
+         */
+        public function testSomething(int $int) {
+          $this->assertEquals(1, $int);
+        }
+      }
+      new MyTestCase;
+      """
+    When I run Psalm
+    Then I see no errors
+
+  Scenario: Invalid dataset shape is reported
+    Given I have the following code
+      """
+      class MyTestCase extends TestCase
+      {
+        /** @return iterable<string,array{string}> */
+        public function provide() {
+          yield "data set name" => ["str"];
+        }
+        /**
+         * @return void
+         * @psalm-suppress UnusedMethod
+         * @dataProvider provide
+         */
+        public function testSomething(int $int) {
+          $this->assertEquals(1, $int);
+        }
+      }
+      new MyTestCase;
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type            | Message                                                                                                                                 |
+      | InvalidArgument | Argument 1 of NS\MyTestCase::testSomething expects int, string provided by NS\MyTestCase::provide():(iterable<string, array{0:string}>) |
+
+  Scenario: Invalid dataset array is reported
+    Given I have the following code
+      """
+      class MyTestCase extends TestCase
+      {
+        /** @return iterable<string,array<int, string|int>> */
+        public function provide() {
+          yield "data set name" => ["str"];
+        }
+        /**
+         * @return void
+         * @psalm-suppress UnusedMethod
+         * @dataProvider provide
+         */
+        public function testSomething(int $int) {
+          $this->assertEquals(1, $int);
+        }
+      }
+      new MyTestCase;
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type                    | Message                                                                                                                                              |
+      | PossiblyInvalidArgument | Argument 1 of NS\MyTestCase::testSomething expects int, string\|int provided by NS\MyTestCase::provide():(iterable<string, array<int, string\|int>>) |
+
+  Scenario: Shape dataset with missing params is reported
+    Given I have the following code
+      """
+      class MyTestCase extends TestCase
+      {
+        /** @return iterable<string,array{int}> */
+        public function provide() {
+          yield "data set name" => [1];
+        }
+        /**
+         * @return void
+         * @psalm-suppress UnusedMethod
+         * @dataProvider provide
+         */
+        public function testSomething(int $int, int $i) {
+          $this->assertEquals(1, $int);
+        }
+      }
+      new MyTestCase;
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type            | Message                                                                                                                                          |
+      | TooFewArguments | Too few arguments for NS\MyTestCase::testSomething - expecting 2 but saw 1 provided by NS\MyTestCase::provide():(iterable<string, array{0:int}>) | 

--- a/tests/acceptance/TestCase.feature
+++ b/tests/acceptance/TestCase.feature
@@ -157,7 +157,7 @@ Feature: TestCase
          * @dataProvider provide
          */
         public function testSomething($int) {
-          $this->assertIsInt($int);
+          $this->assertEquals(1, $int);
         }
       }
       new MyTestCase;

--- a/tests/acceptance/TestCase.feature
+++ b/tests/acceptance/TestCase.feature
@@ -144,3 +144,26 @@ Feature: TestCase
     Then I see these errors
       | Type               | Message                                                                  |
       | MissingConstructor | NS\MyTestCase has an uninitialized variable $this->i, but no constructor | 
+
+  Scenario: Missing data provider is reported
+    Given I have the following code
+    """
+      class MyTestCase extends TestCase
+      {
+        /**
+         * @param mixed $int
+         * @return void
+         * @psalm-suppress UnusedMethod
+         * @dataProvider provide
+         */
+        public function testSomething($int) {
+          $this->assertIsInt($int);
+        }
+      }
+      new MyTestCase;
+    """
+    When I run Psalm
+    Then I see these errors
+      | Type            | Message                                               |
+      | UndefinedMethod | Provider method NS\MyTestCase::provide is not defined |
+    And I see no other errors

--- a/tests/acceptance/TestCase.feature
+++ b/tests/acceptance/TestCase.feature
@@ -29,7 +29,7 @@ Feature: TestCase
     Given I have Psalm newer than "3.0.12" (because of "missing functionality")
     Given I have the following code
       """
-      class MyTestCase extends TestCase 
+      class MyTestCase extends TestCase
       {
         /** @return void */
         public function testSomething() {
@@ -46,7 +46,7 @@ Feature: TestCase
   Scenario: TestCase::expectException() accepts throwables
     Given I have the following code
       """
-      class MyTestCase extends TestCase 
+      class MyTestCase extends TestCase
       {
         /** @return void */
         public function testSomething() {
@@ -123,7 +123,7 @@ Feature: TestCase
 
       interface I { public function work(): int; }
 
-      class MyTestCase extends TestCase 
+      class MyTestCase extends TestCase
       {
         /** @var ObjectProphecy<I> */
         private $i;
@@ -144,7 +144,7 @@ Feature: TestCase
     When I run Psalm
     Then I see these errors
       | Type               | Message                                                                  |
-      | MissingConstructor | NS\MyTestCase has an uninitialized variable $this->i, but no constructor | 
+      | MissingConstructor | NS\MyTestCase has an uninitialized variable $this->i, but no constructor |
     And I see no other errors
 
   Scenario: Missing data provider is reported
@@ -162,7 +162,6 @@ Feature: TestCase
           $this->assertEquals(1, $int);
         }
       }
-      new MyTestCase;
     """
     When I run Psalm
     Then I see these errors
@@ -181,14 +180,12 @@ Feature: TestCase
         }
         /**
          * @return void
-         * @psalm-suppress UnusedMethod
          * @dataProvider provide
          */
         public function testSomething(int $int) {
           $this->assertEquals(1, $int);
         }
       }
-      new MyTestCase;
       """
     When I run Psalm
     Then I see these errors
@@ -207,14 +204,12 @@ Feature: TestCase
         }
         /**
          * @return void
-         * @psalm-suppress UnusedMethod
          * @dataProvider provide
          */
         public function testSomething(int $int) {
           $this->assertEquals(1, $int);
         }
       }
-      new MyTestCase;
       """
     When I run Psalm
     Then I see no errors
@@ -230,14 +225,12 @@ Feature: TestCase
         }
         /**
          * @return void
-         * @psalm-suppress UnusedMethod
          * @dataProvider provide
          */
         public function testSomething(int $int) {
           $this->assertEquals(1, $int);
         }
       }
-      new MyTestCase;
       """
     When I run Psalm
     Then I see these errors
@@ -256,14 +249,12 @@ Feature: TestCase
         }
         /**
          * @return void
-         * @psalm-suppress UnusedMethod
          * @dataProvider provide
          */
         public function testSomething(int $int) {
           $this->assertEquals(1, $int);
         }
       }
-      new MyTestCase;
       """
     When I run Psalm
     Then I see no errors
@@ -279,19 +270,17 @@ Feature: TestCase
         }
         /**
          * @return void
-         * @psalm-suppress UnusedMethod
          * @dataProvider provide
          */
         public function testSomething(int $int) {
           $this->assertEquals(1, $int);
         }
       }
-      new MyTestCase;
       """
     When I run Psalm
     Then I see these errors
-      | Type              | Message                                                                                        |
-      | InvalidReturnType | Providers must return iterable<int\|string, array<array-key, mixed>>, array<int, int> provided |
+      | Type              | Message                                                                                                           |
+      | InvalidReturnType | Providers must return iterable<int\|string, array<array-key, mixed>>, possibly different array<int, int> provided |
     And I see no other errors
 
   Scenario: Valid array data provider is allowed
@@ -307,14 +296,12 @@ Feature: TestCase
         }
         /**
          * @return void
-         * @psalm-suppress UnusedMethod
          * @dataProvider provide
          */
         public function testSomething(int $int) {
           $this->assertEquals(1, $int);
         }
       }
-      new MyTestCase;
       """
     When I run Psalm
     Then I see no errors
@@ -332,14 +319,12 @@ Feature: TestCase
         }
         /**
          * @return void
-         * @psalm-suppress UnusedMethod
          * @dataProvider provide
          */
         public function testSomething(int $int) {
           $this->assertEquals(1, $int);
         }
       }
-      new MyTestCase;
       """
     When I run Psalm
     Then I see no errors
@@ -355,14 +340,12 @@ Feature: TestCase
         }
         /**
          * @return void
-         * @psalm-suppress UnusedMethod
          * @dataProvider provide
          */
         public function testSomething(int $int) {
           $this->assertEquals(1, $int);
         }
       }
-      new MyTestCase;
       """
     When I run Psalm
     Then I see these errors
@@ -381,14 +364,12 @@ Feature: TestCase
         }
         /**
          * @return void
-         * @psalm-suppress UnusedMethod
          * @dataProvider provide
          */
         public function testSomething(int $int) {
           $this->assertEquals(1, $int);
         }
       }
-      new MyTestCase;
       """
     When I run Psalm
     Then I see these errors
@@ -407,19 +388,17 @@ Feature: TestCase
         }
         /**
          * @return void
-         * @psalm-suppress UnusedMethod
          * @dataProvider provide
          */
         public function testSomething(int $int, int $i) {
           $this->assertEquals(1, $int);
         }
       }
-      new MyTestCase;
       """
     When I run Psalm
     Then I see these errors
       | Type            | Message                                                                                                                                          |
-      | TooFewArguments | Too few arguments for NS\MyTestCase::testSomething - expecting 2 but saw 1 provided by NS\MyTestCase::provide():(iterable<string, array{0:int}>) | 
+      | TooFewArguments | Too few arguments for NS\MyTestCase::testSomething - expecting 2 but saw 1 provided by NS\MyTestCase::provide():(iterable<string, array{0:int}>) |
     And I see no other errors
 
   Scenario: Referenced providers are not marked as unused
@@ -433,14 +412,12 @@ Feature: TestCase
         }
         /**
          * @return void
-         * @psalm-suppress UnusedMethod
          * @dataProvider provide
          */
         public function testSomething(int $int) {
           $this->assertEquals(1, $int);
         }
       }
-      new MyTestCase;
       """
     When I run Psalm with dead code detection
     Then I see no errors
@@ -456,13 +433,11 @@ Feature: TestCase
         }
         /**
          * @return void
-         * @psalm-suppress UnusedMethod
          */
         public function testSomething(int $int) {
           $this->assertEquals(1, $int);
         }
       }
-      new MyTestCase;
       """
     When I run Psalm with dead code detection
     Then I see these errors
@@ -489,7 +464,6 @@ Feature: TestCase
           $this->assertEquals(1, $int);
         }
       }
-      new MyTestCase;
       """
     When I run Psalm with dead code detection
     Then I see no errors
@@ -506,11 +480,10 @@ Feature: TestCase
           $this->assertEquals(1, $int);
         }
       }
-      new MyTestCase;
       """
     When I run Psalm with dead code detection
     Then I see these errors
-      | Type                 | Message                                                         | 
+      | Type                 | Message                                                         |
       | PossiblyUnusedMethod | Cannot find public calls to method NS\MyTestCase::somethingElse |
     And I see no other errors
 


### PR DESCRIPTION
# Features
- Check for referenced, but missing data providers
- Check for invalid data provider return types
- Check if referenced data provider provides compatible datasets (based on test method signature)
- Don't report test case classes as unused
- Don't report test methods as unused
- Don't report referenced data providers as unused

# Breaking changes
- Minimum Psalm version is now 3.0.13 (previous versions were missing the hook interface and generic `TIterable`s)

# Miscellaneous
Added more files to phpcs check