### PR TITLE
Don't crash on invalid docblocks

### DIFF
--- a/hooks/TestCaseHandler.php
+++ b/hooks/TestCaseHandler.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use Psalm\CodeLocation;
 use Psalm\Codebase;
 use Psalm\DocComment;
+use Psalm\Exception\DocblockParseException;
 use Psalm\FileSource;
 use Psalm\IssueBuffer;
 use Psalm\Issue;
@@ -528,7 +529,11 @@ class TestCaseHandler implements
         $docblock = $method->getDocComment();
 
         if ($docblock) {
-            $parsed_comment = DocComment::parse((string)$docblock->getReformattedText(), $docblock->getLine());
+            try {
+                $parsed_comment = DocComment::parse((string)$docblock->getReformattedText(), $docblock->getLine());
+            } catch (DocblockParseException $e) {
+                return [];
+            }
             if (isset($parsed_comment['specials'])) {
                 return $parsed_comment['specials'];
             }

--- a/tests/acceptance/TestCase.feature
+++ b/tests/acceptance/TestCase.feature
@@ -1003,3 +1003,48 @@ Feature: TestCase
       """
     When I run Psalm with dead code detection
     Then I see no errors
+
+  Scenario: Invalid psalm annotation on a class does not crash psalm
+    Given I have the following code
+      """
+      /** @psalm-ignore Everything */
+      class MyTestCase extends TestCase {}
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type            | Message         |
+      | InvalidDocblock | %@psalm-ignore% |
+
+  Scenario: Invalid psalm annotation on an before initializer does not crash psalm
+    Given I have the following code
+      """
+      class MyTestCase extends TestCase {
+        /**
+         * @before
+         * @psalm-rm-Rf-slash
+         * @return void
+         */
+        public function preparation() {}
+      }
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type            | Message              |
+      | InvalidDocblock | %@psalm-rm-Rf-slash% |
+
+  Scenario: Invalid psalm annotation on a test does not crash psalm
+    Given I have the following code
+      """
+      class MyTestCase extends TestCase {
+        /**
+         * @test
+         * @psalm-force-push-master
+         * @return void
+         */
+        public function doThings() {}
+      }
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type            | Message                    |
+      | InvalidDocblock | %@psalm-force-push-master% |


### PR DESCRIPTION
Exception is simply suppressed because Psalm will re-analyze (and properly report) invalid docblock without further assistance.

Fixes psalm/phpunit-psalm-plugin#36