### PR TITLE
Amend unionizeIterables to support TList

### DIFF
--- a/hooks/TestCaseHandler.php
+++ b/hooks/TestCaseHandler.php
@@ -390,6 +390,9 @@ class TestCaseHandler implements
                 $value_types[] = $type->getGenericValueType();
             } elseif ($type instanceof Type\Atomic\TNamedObject || $type instanceof Type\Atomic\TIterable) {
                 list($key_types[], $value_types[]) = $codebase->getKeyValueParamsForTraversableObject($type);
+            } elseif ($type instanceof Type\Atomic\TList) {
+                $key_types[] = Type::getInt();
+                $value_types[] = $type->type_param;
             } else {
                 throw new \RuntimeException('unexpected type');
             }


### PR DESCRIPTION
https://psalm.dev/docs/annotating_code/type_syntax/array_types/#lists

> A list type is of the form list<SomeType>, where SomeType is any permitted union type supported by Psalm.
> 
> * `list` is a subtype of `array<int, mixed>`
> * `list<Foo>` is a subtype of `array<int, Foo>`.