### PR TITLE
Fix #[Test] attribute detection for inherited and fully-qualified attributes

### DIFF
--- a/src/Hooks/TestCaseHandler.php
+++ b/src/Hooks/TestCaseHandler.php
@@ -159,7 +159,9 @@ final class TestCaseHandler implements
                 continue;
             }
 
-            $specials = self::getSpecials($stmt_method, $aliases);
+            // Use the declaring class's aliases so trait-declared attributes resolve via the trait's imports.
+            $method_aliases = $declaring_class_storage->aliases ?? $aliases;
+            $specials = self::getSpecials($stmt_method, $method_aliases);
 
             $is_test = 0 === strpos($method_name_lc, 'test') || isset($specials['test']);
             if (!$is_test) {
@@ -561,7 +563,8 @@ final class TestCaseHandler implements
         $attributesInGroupMatchingRequestedAttributeName = static fn(AttributeGroup $group): array => array_filter(
             $group->attrs,
             static fn(Attribute $attribute): bool => $attributeClass === Type::getFQCLNFromString(
-                $attribute->name->toString(),
+                // toCodeString() keeps the leading backslash toString() strips, so fully-qualified attributes resolve.
+                $attribute->name->toCodeString(),
                 $aliases,
             ),
         );

--- a/tests/acceptance/TestCase.feature
+++ b/tests/acceptance/TestCase.feature
@@ -909,6 +909,95 @@ Feature: TestCase
     When I run Psalm with dead code detection
     Then I see no errors
 
+  Scenario: Test methods marked with #[Test] in a trait are not marked as unused when the consuming class does not import the Test attribute
+    Given I have the following code in "MyTestTrait.php"
+      """
+      <?php
+      namespace NS;
+      use PHPUnit\Framework\Attributes\Test;
+      trait MyTestTrait {
+        #[Test]
+        public function itDoesSomething(): void {}
+      }
+      """
+    And I have the following code in "code.php"
+      """
+      <?php
+      namespace NS;
+      use PHPUnit\Framework\TestCase;
+      final class MyTestCase extends TestCase {
+        use MyTestTrait;
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors
+
+  Scenario: Test methods marked with a partially-imported #[Attributes\Test] in a trait are not marked as unused when the consuming class does not import the namespace
+    Given I have the following code in "MyTestTrait.php"
+      """
+      <?php
+      namespace NS;
+      use PHPUnit\Framework\Attributes;
+      trait MyTestTrait {
+        #[Attributes\Test]
+        public function itDoesSomething(): void {}
+      }
+      """
+    And I have the following code in "code.php"
+      """
+      <?php
+      namespace NS;
+      use PHPUnit\Framework\TestCase;
+      final class MyTestCase extends TestCase {
+        use MyTestTrait;
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors
+
+  Scenario: Test methods marked with an aliased #[Test] attribute in a trait are not marked as unused when the consuming class does not import the alias
+    Given I have the following code in "MyTestTrait.php"
+      """
+      <?php
+      namespace NS;
+      use PHPUnit\Framework\Attributes\Test as PHPUnitTest;
+      trait MyTestTrait {
+        #[PHPUnitTest]
+        public function itDoesSomething(): void {}
+      }
+      """
+    And I have the following code in "code.php"
+      """
+      <?php
+      namespace NS;
+      use PHPUnit\Framework\TestCase;
+      final class MyTestCase extends TestCase {
+        use MyTestTrait;
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors
+
+  Scenario: Test methods marked with a fully-qualified #[Test] attribute are not marked as unused
+    Given I have the following code in "BaseTestCase.php"
+      """
+      <?php
+      namespace NS;
+      use PHPUnit\Framework\TestCase;
+      abstract class BaseTestCase extends TestCase {}
+      """
+    And I have the following code in "code.php"
+      """
+      <?php
+      namespace NS;
+      final class MyTestCase extends BaseTestCase {
+        #[\PHPUnit\Framework\Attributes\Test]
+        public function itDoesSomething(): void {}
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors
+
   Scenario: Inherited test methods are not marked as unused
     Given I have the following code
       """


### PR DESCRIPTION
Fixes #158.

`PossiblyUnusedMethod` is reported for methods that are in fact tests, in two cases:

1. **`#[Test]` inherited from a trait (#158).** Specials were resolved with the *consuming* class's aliases instead of the *declaring* trait's. When the consuming class does not import the `Test` attribute, the name no longer resolves to `PHPUnit\Framework\Attributes\Test`, so the method is treated as a non-test.
2. **Fully-qualified `#[\PHPUnit\Framework\Attributes\Test]`.** The name was read via `Name::toString()`, which drops the leading backslash, so it resolves against the current namespace and never matches.

Fix:
- Resolve specials with `$declaring_class_storage->aliases ?? $aliases` (no-op for methods declared on the class itself).
- Read the attribute name via `Name::toCodeString()` so fully-qualified names keep their leading backslash.

Adds acceptance scenarios for inherited `#[Test]` (plain, partial and aliased imports) and fully-qualified attributes; each fails on `master` and passes with this change.